### PR TITLE
イイね機能実装＆ユーザー切替で項目の情報が残っていたので修正

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -6,6 +6,9 @@ class ContentsController < ApplicationController
     @content  = Content.new
     @titles   = Title.all
     @items    = Item.where(items: {title_id: [@title]})
+    @good     = Good.new
+    @goods    = Good.where(content_id: @contents)
+    # binding.pry
   end
 
   def create

--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -1,0 +1,12 @@
+class GoodsController < ApplicationController
+  def create
+    @good = current_user.goods.create(content_id: params[:content_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    @good = Good.find_by(content_id: params[:content_id], user_id: current_user.id)
+    @good.destroy
+    redirect_back(fallback_location: root_path)
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,21 +1,36 @@
 class ItemsController < ApplicationController
   before_action :set_title 
-  @@nan   = -1
-  @@title = 0
+  before_action :set_items, only: [:index, :show]
 
+  @@users = []
+  @@user  = Hash.new { |h,k| h[k] = {} }
+  
   def index
-    @items = Item.where(items: {title_id: [@title]})
-    if @items == [] then
+    if @items == [] then                                            #項目に何もなければ！
       redirect_to new_title_item_path(@title)
-    
-    elsif @@title == @title then
-      @@nan += 1
-      @item  = @items[@@nan]
+    elsif @@user[current_user[:id]] == nil                          #ユーザー情報がなければ！
+      @@user[current_user[:id]][:page]  = 0
+      @@user[current_user[:id]][:title] = @title
+      @@users << @@user
+      @item                             = @@user[current_user[:id]][:page]
       redirect_to title_item_contents_path(@title, @item)
+    elsif @@user[current_user[:id]][:title] == @title then          #タイトルが同じなら
+
+      if @items[@@user[current_user[:id]][:page] + 1]  == nil then  ##次の項目がなければ
+        @@user[current_user[:id]][:page]  = 0
+        @@user[current_user[:id]][:title] = @title
+        @item                             = @items[@@user[current_user[:id]][:page]]
+        redirect_to title_item_contents_path(@title, @item)
+      else
+        @@user[current_user[:id]][:page] += 1                       ##次の項目へ
+        @item  = @items[@@user[current_user[:id]][:page]]
+        redirect_to title_item_contents_path(@title, @item)
+      end
+      
     else
-      @@nan   = 0
-      @@title = @title
-      @item   = @items[@@nan]
+      @@user[current_user[:id]][:page]  = 0                        #別の題目を選んだ時、最初の項目へ
+      @@user[current_user[:id]][:title] = @title
+      @item   = @items[@@user[current_user[:id]][:page]]
       redirect_to title_item_contents_path(@title, @item)
     end
   end 
@@ -25,9 +40,8 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @items = Item.where(items: {title_id: [@title]})
-    @@nan -= 1
-    @item  = @items[@@nan]
+    @@user[current_user[:id]][:page] -= 1             #前の項目へ
+    @item  = @items[@@user[current_user[:id]][:page]]
     redirect_to title_item_contents_path(@title, @item)
   end
 
@@ -44,5 +58,9 @@ class ItemsController < ApplicationController
 
   def set_title
     @title = Title.find(params[:title_id])
+  end
+
+  def set_items
+    @items = Item.where(items: {title_id: [@title]})
   end
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -1,4 +1,6 @@
 class Content < ApplicationRecord
   belongs_to :user
   belongs_to :item
+  has_many :goods, dependent: :destroy
+  has_many :good_users, through: :goods, source: :user
 end

--- a/app/models/good.rb
+++ b/app/models/good.rb
@@ -1,0 +1,5 @@
+class Good < ApplicationRecord
+  belongs_to :content
+  belongs_to :user
+  validates_uniqueness_of :content_id, scope: :user_id
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
   belongs_to :title
   belongs_to :user
-  has_many   :contents
+  has_many   :contents, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,12 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
-  belongs_to :content
+  has_many :contents
+  has_many :goods
+  has_many :good_contents, through: :goods, source: :content
   validates :name, presence: true
+
+  def already_good?(content)
+    self.goods.exists?(content_id: content.id)
+  end
 end

--- a/app/views/contents/_maine_chat.html.haml
+++ b/app/views/contents/_maine_chat.html.haml
@@ -18,9 +18,14 @@
         .content__comment__text
           = content.content
         .content__comment__icon
-          =link_to "" do
-            = icon('fas', 'heart', class: "content__comment__icon--hart")
-
+          - if current_user.already_good?(content)
+            = link_to title_item_content_good_path(@title, @item, content, content), method: :delete do
+              = icon('fas', 'heart', class: "content__comment__icon--hart")
+            = @goods.where(content_id: content).count
+          - else
+            = link_to title_item_content_goods_path(@title, @item, content), method: :post do
+              = icon('fas', 'heart', class: "content__comment__icon--hart")
+            = @goods.where(content_id: content).count
   .footer
     .footer__plus
       = link_to new_title_item_path do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,10 @@ Rails.application.routes.draw do
   root "titles#index"
   resources :titles, only: :index do
     resources :items, only: [:index, :new, :create ,:show]do
-      resources :contents, only: [:index, :create]
+      resources :contents, only: [:index, :create] do
+        resources :goods, only: [:create, :destroy]
+      end
     end
   end
+  
 end

--- a/db/migrate/20200309015620_create_goods.rb
+++ b/db/migrate/20200309015620_create_goods.rb
@@ -1,0 +1,10 @@
+class CreateGoods < ActiveRecord::Migration[5.0]
+  def change
+    create_table :goods do |t|
+      t.references :content, foreign_key: true
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200308125708) do
+ActiveRecord::Schema.define(version: 20200309015620) do
 
   create_table "contents", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "content",    limit: 50, default: "", null: false
@@ -20,6 +20,15 @@ ActiveRecord::Schema.define(version: 20200308125708) do
     t.datetime "updated_at",                         null: false
     t.index ["item_id"], name: "index_contents_on_item_id", using: :btree
     t.index ["user_id"], name: "index_contents_on_user_id", using: :btree
+  end
+
+  create_table "goods", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "content_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_id"], name: "index_goods_on_content_id", using: :btree
+    t.index ["user_id"], name: "index_goods_on_user_id", using: :btree
   end
 
   create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -56,6 +65,8 @@ ActiveRecord::Schema.define(version: 20200308125708) do
 
   add_foreign_key "contents", "items"
   add_foreign_key "contents", "users"
+  add_foreign_key "goods", "contents"
+  add_foreign_key "goods", "users"
   add_foreign_key "items", "titles"
   add_foreign_key "items", "users"
 end


### PR DESCRIPTION
#What
・イイね機能の実装
・項目の情報が残る不具合の修正

#Why
・イイね機能の実装する事でcontentの並び替えの実装に必要な為
・他のユーザーで使用した時に情報が残り、前の人の続きからの項目からになる不具合の為に修正